### PR TITLE
Add the flask_analytics.providers package to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,7 @@ setup(
     author="Mihir Singh (@citruspi)",
     author_email="hello@mihirsingh.com",
     url='https://github.com/citruspi/Flask-Analytics',
-    packages=['flask_analytics'],
+    packages=['flask_analytics', 'flask_analytics.providers'],
     zip_safe=False,
     include_package_data=True,
     platforms='any',


### PR DESCRIPTION
Fixes the problems related to providers not being installed in this issue: https://github.com/citruspi/Flask-Analytics/issues/4