### PR TITLE
Python 3 compatibility

### DIFF
--- a/flask_analytics/analytics.py
+++ b/flask_analytics/analytics.py
@@ -79,7 +79,7 @@ class Analytics(object):
             if 'ENABLED' in args:
                 del args['ENABLED']
 
-            for key in args:
+            for key in list(args):
                 args[key.lower()] = args.pop(key)
 
             instance = self.provider_map[provider](**args)

--- a/flask_analytics/analytics.py
+++ b/flask_analytics/analytics.py
@@ -42,7 +42,7 @@ class Analytics(object):
                 'ENABLED': True
             }
 
-            args = self.provider_map[provider].__init__.func_code.co_varnames
+            args = self.provider_map[provider].__init__.__code__.co_varnames
             args = [arg for arg in args if arg != 'self']
 
             for arg in args:

--- a/test/test_app.py
+++ b/test/test_app.py
@@ -1,4 +1,5 @@
 import unittest
+import re
 from app import app, analytics
 
 class TestAnalytics(unittest.TestCase):
@@ -41,7 +42,7 @@ class TestAnalytics(unittest.TestCase):
 
         expected = ""
 
-        self.assertEquals(response.data, expected)
+        self.assertEquals(response.data, expected.encode('utf8'))
 
     def test_disabled(self):
 
@@ -51,7 +52,7 @@ class TestAnalytics(unittest.TestCase):
 
         expected = ""
 
-        self.assertEquals(response.data, expected)
+        self.assertEquals(response.data, expected.encode('utf8'))
 
 
     def test_chartbeat(self):
@@ -81,7 +82,7 @@ class TestAnalytics(unittest.TestCase):
     })();
 </script>"""
 
-        self.assertEquals(response.data, expected)
+        self.assertEquals(response.data, expected.encode('utf8'))
 
     def test_gosquared(self):
 
@@ -98,7 +99,7 @@ class TestAnalytics(unittest.TestCase):
     _gs('ahz1Nahqueorahw');
 </script>"""
 
-        self.assertEquals(response.data, expected)
+        self.assertEquals(response.data, expected.encode('utf8'))
 
     def test_piwik(self):
 
@@ -119,7 +120,7 @@ class TestAnalytics(unittest.TestCase):
     })();
 </script>"""
 
-        self.assertEquals(response.data, expected)
+        self.assertEquals(response.data, expected.encode('utf8'))
 
     def test_gauges(self):
 
@@ -141,7 +142,7 @@ class TestAnalytics(unittest.TestCase):
     })();
 </script>"""
 
-        self.assertEquals(response.data, expected)
+        self.assertEquals(response.data, expected.encode('utf8'))
 
     def test_google(self):
 
@@ -163,7 +164,7 @@ class TestAnalytics(unittest.TestCase):
 
 </script>"""
 
-        self.assertEquals(response.data, expected)
+        self.assertEquals(response.data, expected.encode('utf8'))
 
     def test_all(self):
 
@@ -238,4 +239,9 @@ class TestAnalytics(unittest.TestCase):
     })();
 </script>"""
 
-        self.assertEquals(response.data, expected)
+
+
+        response_sections = sorted(re.split('<|>',str(response.data)))
+        expected_sections = sorted(re.split('<|>',str(expected.encode('utf'))))
+
+        self.assertEquals(response_sections, expected_sections)


### PR DESCRIPTION
You nearly had it.

`my_function.__code__` is backwards compatible (at least to 2.7)

The order of the js snippets isn't important, only their content is. For whatever reason, Py3 orders them differently.

`str(expected.encode('utf8'))` is needed since UTF8 and ascii sort differently.